### PR TITLE
Support many forms of search spaces

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -25,6 +25,7 @@ julia = "1"
 
 [extras]
 DecisionTree = "7806a523-6efd-50cb-b5f6-3fa6f1930dbb"
+MLJDecisionTreeInterface = "c6f25543-311c-4c74-83dc-3ea6d1015661"
 MLJBase = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
 MLJModels = "d491faf4-2d78-11e9-2867-c94bc002c0b7"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
@@ -32,4 +33,4 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["DecisionTree", "MLJBase", "MLJModels", "Statistics", "StatsBase", "Test"]
+test = ["DecisionTree", "MLJDecisionTreeInterface", "MLJBase", "MLJModels", "Statistics", "StatsBase", "Test"]

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The space is a collection which describes the parameter ranges and choices that 
 
 Each `HP.*` function needs to be given the name again as the first parameter, and then further arguments as relevant to the function. [Instructions are available](docs/hyperparams.md).
 
-If using a dictionary form, the key is the what be the name of the parameter. Additionall, elements of the space can be nested inside each other. Here is an example:
+If using a dictionary form, the key is the what be the name of the parameter. Additionally, elements of the space can be nested inside each other. Here is an example:
 
 ```julia
 using TreeParzen

--- a/README.md
+++ b/README.md
@@ -53,11 +53,11 @@ invert_output(params...) = - actual_function(params...)
 
 ### Spaces
 
-The space is a `Dict` that describes the parameter ranges and choices that can be made. These can be expressed using a family of functions from [the `HP` module](src/HP.jl).
+The space is a collection which describes the parameter ranges and choices that can be made. These can be expressed using a family of functions from [the `HP` module](src/HP.jl).
 
-Each function needs to be given the name again as the first parameter, and then further arguments as relevant to the function. [Instructions are available](docs/hyperparams.md).
+Each `HP.*` function needs to be given the name again as the first parameter, and then further arguments as relevant to the function. [Instructions are available](docs/hyperparams.md).
 
-The dictionary key should be the name of the parameter as a string. Elements of the space can be nested inside each other. Here is an example:
+If using a dictionary form, the key is the what be the name of the parameter. Additionall, elements of the space can be nested inside each other. Here is an example:
 
 ```julia
 using TreeParzen
@@ -79,6 +79,13 @@ space = Dict(
         ]
     )
 )
+```
+
+Other examples of valid spaces include:
+
+```julia
+space = HP.Choice(:a_scalar_sampler, [1, 2]) # will select from 1,2
+space = [HP.Choice(:firstel, [10, 100]), HP.Uniform(:seconel, 5., 10.)] # first element will be selected from 10,100 and 2nd element uniformly from 5-10
 ```
 
 ### fmin sample usage

--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ This allows users to do advanced things such as wrapping up objectives in
 a more complex way, using callbacks, controlling termination, optimising after N suggestions,
 continuing iterating if solution is not satisfactory, and so on.
 
+One should call `Graph.checkspace(space)` prior to using `ask` -- to avoid inefficiency of repeatedly
+checking the space is valid for each ask the user is required to do this themselves.
+
 A basic example:
 ```julia
 using TreeParzen
@@ -116,6 +119,7 @@ config = Config()
 trialhist = TreeParzen.Trials.Trial[]
 
 space = Dict(:x => HP.Uniform(:x, -5., 5.))
+TreeParzen.Graph.checkspace(space)
 
 for i in 1:100
 

--- a/src/API.jl
+++ b/src/API.jl
@@ -21,8 +21,6 @@ Also can generate trials to be evaluated from Dict of points.
 """
 function ask(space::Types.SPACE_TYPE)::Trials.Trial
 
-    Graph.checkspace(space)
-
     vals = Trials.ValsDict()
     hyperparams = Resolve.node(space, vals)
 
@@ -33,8 +31,6 @@ $(TYPEDSIGNATURES)
 Provides a suggestion based on tree-parzen estimation
 """
 function ask(space::Types.SPACE_TYPE, trials::Vector{Trials.Trial}, config::Config)::Trials.Trial
-
-    Graph.checkspace(space)
 
     # Run a few initial random jobs before doing tree-parzen.
     if length(trials) < config.random_trials

--- a/src/API.jl
+++ b/src/API.jl
@@ -21,6 +21,8 @@ Also can generate trials to be evaluated from Dict of points.
 """
 function ask(space::Types.SPACE_TYPE)::Trials.Trial
 
+    Graph.checkspace(space)
+
     vals = Trials.ValsDict()
     hyperparams = Resolve.node(space, vals)
 
@@ -31,6 +33,8 @@ $(TYPEDSIGNATURES)
 Provides a suggestion based on tree-parzen estimation
 """
 function ask(space::Types.SPACE_TYPE, trials::Vector{Trials.Trial}, config::Config)::Trials.Trial
+
+    Graph.checkspace(space)
 
     # Run a few initial random jobs before doing tree-parzen.
     if length(trials) < config.random_trials

--- a/src/API.jl
+++ b/src/API.jl
@@ -7,6 +7,7 @@ import ..Delayed
 import ..Graph
 import ..Resolve
 import ..Trials
+import ..Types
 
 export ask
 export fmin
@@ -18,7 +19,7 @@ $(TYPEDSIGNATURES)
 Provides a suggestion based on random search to generate hyperparameter values.
 Also can generate trials to be evaluated from Dict of points.
 """
-function ask(space::Dict{Symbol, T} where T)::Trials.Trial
+function ask(space::Types.SPACE_TYPE)::Trials.Trial
 
     vals = Trials.ValsDict()
     hyperparams = Resolve.node(space, vals)
@@ -29,7 +30,7 @@ end
 $(TYPEDSIGNATURES)
 Provides a suggestion based on tree-parzen estimation
 """
-function ask(space::Dict{Symbol, T} where T, trials::Vector{Trials.Trial}, config::Config)::Trials.Trial
+function ask(space::Types.SPACE_TYPE, trials::Vector{Trials.Trial}, config::Config)::Trials.Trial
 
     # Run a few initial random jobs before doing tree-parzen.
     if length(trials) < config.random_trials
@@ -142,7 +143,7 @@ Example:
 
 """
 function run(
-    points::Vector{Trials.Trial}, fn::Function, space::Dict{Symbol, T} where T, N::Int,
+    points::Vector{Trials.Trial}, fn::Function, space::Types.SPACE_TYPE, N::Int,
     config::Config;
     logging_interval::Int = -1,
 )::Vector{Trials.Trial}
@@ -216,7 +217,7 @@ Find the set of hyperparameters that return the lowest value from the submitted 
     statement be logged out. Default, -1, will log only upon completion.
 """
 function fmin(
-    fn::Function, space::Dict{Symbol, T} where T, N::Int, points::Vector{Trials.Trial};
+    fn::Function, space::Types.SPACE_TYPE, N::Int, points::Vector{Trials.Trial};
     threshold::Float64 = 0.25, linear_forgetting::Int = 25, draws::Int = 24,
     random_trials::Int = 20, prior_weight::Float64 = 1.0, logging_interval::Int = -1,
 )
@@ -232,8 +233,8 @@ function fmin(
     return API.provide_recommendation(trials)
 end
 function fmin(
-    fn::Function, space::Dict{Symbol, T} where T, N::Int,
-    points::Vector{<: Dict{Symbol, T} where T}; kwargs...
+    fn::Function, space::Types.SPACE_TYPE, N::Int,
+    points::Vector{<: Types.SPACE_TYPE}; kwargs...
 )
     if N < length(points)
         throw(ArgumentError(string(
@@ -244,7 +245,7 @@ function fmin(
 
     return fmin(fn, space, N, API.ask.(points); kwargs...)
 end
-function fmin(fn::Function, space::Dict{Symbol, T} where T, N::Int; kwargs...)
+function fmin(fn::Function, space::Types.SPACE_TYPE, N::Int; kwargs...)
     return fmin(fn, space, N, Trials.Trial[]; kwargs...)
 end
 

--- a/src/API.jl
+++ b/src/API.jl
@@ -19,7 +19,7 @@ $(TYPEDSIGNATURES)
 Provides a suggestion based on random search to generate hyperparameter values.
 Also can generate trials to be evaluated from Dict of points.
 """
-function ask(space::Types.SPACE_TYPE)::Trials.Trial
+function ask(space)::Trials.Trial
 
     vals = Trials.ValsDict()
     hyperparams = Resolve.node(space, vals)

--- a/src/Delayed/Delayed.jl
+++ b/src/Delayed/Delayed.jl
@@ -6,21 +6,20 @@ using DocStringExtensions
 
 import ..IndexObjects
 import ..SpacePrint
+import ..Types
 
-"""Delayed objects sit in the space representing simple functions to be run later"""
-abstract type AbstractDelayed end
 
 """DistDelayed objects represent functions that draw output from distributions"""
-abstract type AbstractDistDelayed <: AbstractDelayed end
-const NestedFloat = Union{AbstractDelayed, Float64}
+abstract type AbstractDistDelayed <: Types.AbstractDelayed end
+const NestedFloat = Union{Types.AbstractDelayed, Float64}
 
 """Switch objects represent a choice between options"""
-abstract type AbstractSwitch <: AbstractDelayed end
+abstract type AbstractSwitch <: Types.AbstractDelayed end
 
 """Allow Delayed objects to contain other Delayed objects"""
-const NestedFloat = Union{AbstractDelayed, Float64}
-const NestedInt = Union{AbstractDelayed, Int}
-const NestedReal = Union{AbstractDelayed, Real}
+const NestedFloat = Union{Types.AbstractDelayed, Float64}
+const NestedInt = Union{Types.AbstractDelayed, Int}
+const NestedReal = Union{Types.AbstractDelayed, Real}
 
 include("add.jl")
 include("categoricalindex.jl")
@@ -37,7 +36,7 @@ include("quantuniform.jl")
 include("logquantuniform.jl")
 
 function SpacePrint.spaceprint(
-    item::AbstractDelayed; index::Int = 1, tab::String = "", corner::String = "",
+    item::Types.AbstractDelayed; index::Int = 1, tab::String = "", corner::String = "",
     final::Bool = true
 )::Nothing
     println(tab, corner, index, ": ", typeof(item))

--- a/src/Delayed/add.jl
+++ b/src/Delayed/add.jl
@@ -3,11 +3,11 @@ $(TYPEDEF)
 $(TYPEDFIELDS)
 
 """
-struct Add <: AbstractDelayed
+struct Add <: Types.AbstractDelayed
     left::NestedReal
     right::NestedReal
 end
 
-Base.:+(left::AbstractDelayed, right::AbstractDelayed) = Add(left, right)
-Base.:+(left::AbstractDelayed, right::Real) = Add(left, right)
-Base.:+(left::Real, right::AbstractDelayed) = Add(left, right)
+Base.:+(left::Types.AbstractDelayed, right::Types.AbstractDelayed) = Add(left, right)
+Base.:+(left::Types.AbstractDelayed, right::Real) = Add(left, right)
+Base.:+(left::Real, right::Types.AbstractDelayed) = Add(left, right)

--- a/src/Delayed/float.jl
+++ b/src/Delayed/float.jl
@@ -3,8 +3,8 @@ $(TYPEDEF)
 $(TYPEDFIELDS)
 
 """
-struct Float <: AbstractDelayed
-    arg::AbstractDelayed
+struct Float <: Types.AbstractDelayed
+    arg::Types.AbstractDelayed
 end
 
-Base.float(arg::AbstractDelayed) = Float(arg)
+Base.float(arg::Types.AbstractDelayed) = Float(arg)

--- a/src/Delayed/params.jl
+++ b/src/Delayed/params.jl
@@ -1,4 +1,4 @@
-abstract type AbstractParam <: AbstractDelayed end
+abstract type AbstractParam <: Types.AbstractDelayed end
 
 """
 $(TYPEDSIGNATURES)
@@ -9,5 +9,5 @@ a corresponding Param object in the space.
 """
 struct Param <: AbstractParam
     label::Symbol
-    obj::AbstractDelayed
+    obj::Types.AbstractDelayed
 end

--- a/src/Delayed/randindex.jl
+++ b/src/Delayed/randindex.jl
@@ -6,7 +6,7 @@ $(TYPEDFIELDS)
 struct RandIndex <: AbstractDistDelayed
     upper::NestedInt
 
-    RandIndex(upper::AbstractDelayed) = new(upper)
+    RandIndex(upper::Types.AbstractDelayed) = new(upper)
     function RandIndex(upper::Int)
         if upper < 1
             throw(ArgumentError("upper will be used as index so must be greater than 0"))

--- a/src/Graph.jl
+++ b/src/Graph.jl
@@ -2,6 +2,7 @@ module Graph
 
 using DocStringExtensions
 
+import ..Types
 import ..Delayed
 
 """
@@ -9,7 +10,7 @@ $(TYPEDSIGNATURES)
 
 Given an delayed object, return an array of argument values.
 """
-function delayedproperties(item::Delayed.AbstractDelayed)::Vector
+function delayedproperties(item::Types.AbstractDelayed)::Vector
 
     return [
         getproperty(item, propertyname)
@@ -26,14 +27,14 @@ $(TYPEDSIGNATURES)
 Depth-first search
 Unrolls a graph into an array of all the nodes.
 """
-dfs(space::Dict{Symbol, T} where T)::Vector = dfs!(Delayed.AbstractDelayed[], space)
+dfs(space::Dict{Symbol, T} where T)::Vector = dfs!(Types.AbstractDelayed[], space)
 
 """
 $(TYPEDSIGNATURES)
 
-Unrolls a nested space into a vector of all the Delayed.AbstractDelayed nodes.
+Unrolls a nested space into a vector of all the Types.AbstractDelayed nodes.
 """
-function dfs!(seq::Vector{Delayed.AbstractDelayed}, item::Delayed.AbstractDelayed)::Vector
+function dfs!(seq::Vector{Types.AbstractDelayed}, item::Types.AbstractDelayed)::Vector
     # For every input (arg) of the object, add those to the list too.
     for prop in delayedproperties(item)
         dfs!(seq, prop)
@@ -42,21 +43,21 @@ function dfs!(seq::Vector{Delayed.AbstractDelayed}, item::Delayed.AbstractDelaye
 
     return seq
 end
-function dfs!(seq::Vector{Delayed.AbstractDelayed}, item::Dict)::Vector
+function dfs!(seq::Vector{Types.AbstractDelayed}, item::Dict)::Vector
     for v in values(item)
         dfs!(seq, v)
     end
 
     return seq
 end
-function dfs!(seq::Vector{Delayed.AbstractDelayed}, item::Union{Tuple, Vector})::Vector
+function dfs!(seq::Vector{Types.AbstractDelayed}, item::Union{Tuple, Vector})::Vector
     for v in item
         dfs!(seq, v)
     end
 
     return seq
 end
-dfs!(seq::Vector{Delayed.AbstractDelayed}, item::Any)::Vector = seq
+dfs!(seq::Vector{Types.AbstractDelayed}, item::Any)::Vector = seq
 
 function checklabel!(labels::Vector{Symbol}, node::Delayed.AbstractParam)::Nothing
     if node.label in labels

--- a/src/Graph.jl
+++ b/src/Graph.jl
@@ -27,7 +27,7 @@ $(TYPEDSIGNATURES)
 Depth-first search
 Unrolls a graph into an array of all the nodes.
 """
-dfs(space::Dict{Symbol, T} where T)::Vector = dfs!(Types.AbstractDelayed[], space)
+dfs(space::Types.SPACE_TYPE)::Vector = dfs!(Types.AbstractDelayed[], space)
 
 """
 $(TYPEDSIGNATURES)
@@ -74,13 +74,13 @@ $(TYPEDSIGNATURES)
 
 Ensure the user hasn't submitted any duplicate labels in their space.
 """
-function checkspace(space::Dict{Symbol, T})::Dict{Symbol, T} where T
+function checkspace(space::Types.SPACE_TYPE)::Nothing
     labels = Symbol[]
     for node in Graph.dfs(space)
         checklabel!(labels, node)
     end
 
-    return space
+    return nothing
 end
 
 end # module Graph

--- a/src/MLJTreeParzen.jl
+++ b/src/MLJTreeParzen.jl
@@ -83,6 +83,13 @@ struct MLJTreeParzenSpace
     The number of random warn-up rounds is reduced by the amount of suggestions provided
     """
     suggestions::Vector{Dict{Symbol}}
+
+    # use an inner constructor to check now that checkspace returns nothing
+    function MLJTreeParzenSpace(space, suggestions)
+        Graph.checkspace(space)
+        return new(space, suggestions)
+    end
+
 end
 
 """
@@ -103,9 +110,7 @@ search = MLJTreeParzen.MLJTreeParzenSpace(
 );
 ```
 """
-MLJTreeParzenSpace(input_space::Dict{Symbol}) = MLJTreeParzenSpace(
-    Graph.checkspace(input_space), Dict{Symbol}[]
-)
+MLJTreeParzenSpace(input_space::Dict{Symbol}) = MLJTreeParzenSpace(input_space, Dict{Symbol}[])
 """
 $(TYPEDSIGNATURES)
 
@@ -144,9 +149,7 @@ search = MLJTreeParzen.MLJTreeParzenSpace(
 ```
 
 """
-MLJTreeParzenSpace(input_space::Dict{Symbol}, suggestion::Dict{Symbol}) = MLJTreeParzenSpace(
-    Graph.checkspace(input_space), [suggestion]
-)
+MLJTreeParzenSpace(input_space::Dict{Symbol}, suggestion::Dict{Symbol}) = MLJTreeParzenSpace(input_space, [suggestion])
 
 
 """
@@ -206,7 +209,7 @@ get_trialhist(history) =
         trial_object = entry.metadata
         measurement = entry.measurement[1]
         # @ablaom asks "Is this deepcopy really necessary?":
-        completed_trial = deepcopy(trial_object) 
+        completed_trial = deepcopy(trial_object)
         tell!(completed_trial, first(measurement))
         completed_trial
     end
@@ -228,7 +231,7 @@ function MLJTuning.models(
     # get an up-to-date the history of trial objects by appending to
     # the trial object history stored in `state`:
     recent_history =
-        view(vector(history), (length(trialhist) + 1):num_hist) 
+        view(vector(history), (length(trialhist) + 1):num_hist)
     recent_trialhist = get_trialhist(recent_history)
     trialhist = vcat(state.trialhist, recent_trialhist)
 

--- a/src/Resolve/Resolve.jl
+++ b/src/Resolve/Resolve.jl
@@ -12,6 +12,7 @@ import ..LogGMM
 import ..Resolve
 import ..Samplers
 import ..Trials
+import ..Types
 
 include("posterior.jl")
 include("nodes.jl")

--- a/src/Resolve/nodes.jl
+++ b/src/Resolve/nodes.jl
@@ -11,8 +11,8 @@ Resolves a posterior inference space by depth-first iteration, replacing prior r
 variables with new posterior distributions that make use of observations.
 """
 function node(
-    space::Dict{Symbol, T} where T, trials::Vector{Trials.Trial}, config::Config
-)::Tuple{Trials.ValsDict, Dict{Symbol, T} where T}
+    space::Types.SPACE_TYPE, trials::Vector{Trials.Trial}, config::Config
+)::Tuple{Trials.ValsDict, Any}
 
     params = Dict{Symbol, Types.AbstractDelayed}(
         item.label => item.obj

--- a/src/Resolve/nodes.jl
+++ b/src/Resolve/nodes.jl
@@ -14,7 +14,7 @@ function node(
     space::Dict{Symbol, T} where T, trials::Vector{Trials.Trial}, config::Config
 )::Tuple{Trials.ValsDict, Dict{Symbol, T} where T}
 
-    params = Dict{Symbol, Delayed.AbstractDelayed}(
+    params = Dict{Symbol, Types.AbstractDelayed}(
         item.label => item.obj
             for item in Graph.dfs(space)
                 if walkable(item)
@@ -29,7 +29,7 @@ end
 
 
 function obs_memo(
-    item::Delayed.AbstractDistDelayed, params::Dict{Symbol, Delayed.AbstractDelayed}
+    item::Delayed.AbstractDistDelayed, params::Dict{Symbol, Types.AbstractDelayed}
 )::Symbol
     for (k, v) in params
         v == item && return k
@@ -61,7 +61,7 @@ $(TYPEDSIGNATURES)
 Resolves random search AbstractParam nodes and places parameter results in the vals dictionary.
 """
 function node(
-    item::Delayed.AbstractParam, vals::Trials.ValsDict, params::Dict{Symbol, Delayed.AbstractDelayed},
+    item::Delayed.AbstractParam, vals::Trials.ValsDict, params::Dict{Symbol, Types.AbstractDelayed},
     trials::Vector{Trials.Trial}, config::Config
 )::Union{IndexObjects.IndexInt, Real}
     if haskey(vals, item.label)
@@ -83,7 +83,7 @@ function node(item::Delayed.Add, vals::Trials.ValsDict)::Real
     return left + right
 end
 function node(
-    item::Delayed.Add, vals::Trials.ValsDict, params::Dict{Symbol, Delayed.AbstractDelayed},
+    item::Delayed.Add, vals::Trials.ValsDict, params::Dict{Symbol, Types.AbstractDelayed},
     trials::Vector{Trials.Trial}, config::Config
 )::Float64
 
@@ -99,7 +99,7 @@ function node(item::Delayed.CategoricalIndex, vals::Trials.ValsDict)::IndexObjec
 end
 function node(
     item::Delayed.CategoricalIndex, vals::Trials.ValsDict,
-    params::Dict{Symbol, Delayed.AbstractDelayed}, trials::Vector{Trials.Trial},
+    params::Dict{Symbol, Types.AbstractDelayed}, trials::Vector{Trials.Trial},
     config::Config
 )::IndexObjects.IndexInt
 
@@ -121,7 +121,7 @@ function node(item::Dict{Symbol, T} where T, vals::Trials.ValsDict)::Dict{Symbol
 end
 function node(
     item::Dict{Symbol, T} where T, vals::Trials.ValsDict,
-    params::Dict{Symbol, Delayed.AbstractDelayed}, trials::Vector{Trials.Trial},
+    params::Dict{Symbol, Types.AbstractDelayed}, trials::Vector{Trials.Trial},
     config::Config
 )::Dict{Symbol, Any}
 
@@ -140,7 +140,7 @@ function node(item::Delayed.Float, vals::Trials.ValsDict)::Float64
     return float(node(item.arg, vals))
 end
 function node(
-    item::Delayed.Float, vals::Trials.ValsDict, params::Dict{Symbol, Delayed.AbstractDelayed},
+    item::Delayed.Float, vals::Trials.ValsDict, params::Dict{Symbol, Types.AbstractDelayed},
     trials::Vector{Trials.Trial}, config::Config
 )::Float64
 
@@ -156,7 +156,7 @@ function node(item::Delayed.LogNormal, vals::Trials.ValsDict)::Float64
 end
 function node(
     item::Delayed.LogNormal, vals::Trials.ValsDict,
-    params::Dict{Symbol, Delayed.AbstractDelayed}, trials::Vector{Trials.Trial},
+    params::Dict{Symbol, Types.AbstractDelayed}, trials::Vector{Trials.Trial},
     config::Config
 )::Real
 
@@ -177,7 +177,7 @@ function node(item::Delayed.LogQuantNormal, vals::Trials.ValsDict)::Float64
 end
 function node(
     item::Delayed.LogQuantNormal, vals::Trials.ValsDict,
-    params::Dict{Symbol, Delayed.AbstractDelayed}, trials::Vector{Trials.Trial},
+    params::Dict{Symbol, Types.AbstractDelayed}, trials::Vector{Trials.Trial},
     config::Config
 )::Real
 
@@ -197,7 +197,7 @@ function node(item::Delayed.Normal, vals::Trials.ValsDict)::Float64
     return Delayed.normal(mu, sigma)
 end
 function node(
-    item::Delayed.Normal, vals::Trials.ValsDict, params::Dict{Symbol, Delayed.AbstractDelayed},
+    item::Delayed.Normal, vals::Trials.ValsDict, params::Dict{Symbol, Types.AbstractDelayed},
     trials::Vector{Trials.Trial}, config::Config
 )::Real
 
@@ -216,7 +216,7 @@ function node(item::Delayed.QuantNormal, vals::Trials.ValsDict)::Float64
     return Delayed.quantnormal(mu, sigma, q)
 end
 function node(
-    item::Delayed.QuantNormal, vals::Trials.ValsDict, params::Dict{Symbol, Delayed.AbstractDelayed},
+    item::Delayed.QuantNormal, vals::Trials.ValsDict, params::Dict{Symbol, Types.AbstractDelayed},
     trials::Vector{Trials.Trial}, config::Config
 )::Real
 
@@ -239,7 +239,7 @@ function node(item::Delayed.RandIndex, vals::Trials.ValsDict)::IndexObjects.Inde
     return IndexObjects.IndexInt(rand(1:upper))
 end
 function node(
-    item::Delayed.RandIndex, vals::Trials.ValsDict, params::Dict{Symbol, Delayed.AbstractDelayed},
+    item::Delayed.RandIndex, vals::Trials.ValsDict, params::Dict{Symbol, Types.AbstractDelayed},
     trials::Vector{Trials.Trial}, config::Config
 )::IndexObjects.IndexInt
 
@@ -261,7 +261,7 @@ function node(item::Delayed.AbstractSwitch, vals::Trials.ValsDict)
     return node(item.options[choice.v], vals)
 end
 function node(
-    item::Delayed.AbstractSwitch, vals::Trials.ValsDict, params::Dict{Symbol, Delayed.AbstractDelayed},
+    item::Delayed.AbstractSwitch, vals::Trials.ValsDict, params::Dict{Symbol, Types.AbstractDelayed},
     trials::Vector{Trials.Trial}, config::Config
 )
     choice = node(item.choice, vals, params, trials, config)
@@ -277,7 +277,7 @@ function node(item::Delayed.Uniform, vals::Trials.ValsDict)::Float64
     return Delayed.uniform(low, high)
 end
 function node(
-    item::Delayed.Uniform, vals::Trials.ValsDict, params::Dict{Symbol, Delayed.AbstractDelayed},
+    item::Delayed.Uniform, vals::Trials.ValsDict, params::Dict{Symbol, Types.AbstractDelayed},
     trials::Vector{Trials.Trial}, config::Config
 )::Real
 
@@ -296,7 +296,7 @@ function node(item::Delayed.QuantUniform, vals::Trials.ValsDict)::Float64
     return Delayed.quantuniform(low, high, q)
 end
 function node(
-    item::Delayed.QuantUniform, vals::Trials.ValsDict, params::Dict{Symbol, Delayed.AbstractDelayed},
+    item::Delayed.QuantUniform, vals::Trials.ValsDict, params::Dict{Symbol, Types.AbstractDelayed},
     trials::Vector{Trials.Trial}, config::Config
 )::Real
 
@@ -318,7 +318,7 @@ end
 
 function node(
     item::Delayed.LogUniform, vals::Trials.ValsDict,
-    params::Dict{Symbol, Delayed.AbstractDelayed}, trials::Vector{Trials.Trial},
+    params::Dict{Symbol, Types.AbstractDelayed}, trials::Vector{Trials.Trial},
     config::Config
 )::Real
 
@@ -338,7 +338,7 @@ function node(item::Delayed.LogQuantUniform, vals::Trials.ValsDict)::Float64
 end
 function node(
     item::Delayed.LogQuantUniform, vals::Trials.ValsDict,
-    params::Dict{Symbol, Delayed.AbstractDelayed}, trials::Vector{Trials.Trial},
+    params::Dict{Symbol, Types.AbstractDelayed}, trials::Vector{Trials.Trial},
     config::Config
 )::Real
 
@@ -357,7 +357,7 @@ function node(items::Vector, vals::Trials.ValsDict)::Vector{<: Any}
     ]
 end
 function node(
-    items::Vector, vals::Trials.ValsDict, params::Dict{Symbol, Delayed.AbstractDelayed},
+    items::Vector, vals::Trials.ValsDict, params::Dict{Symbol, Types.AbstractDelayed},
     trials::Vector{Trials.Trial}, config::Config
 )::Vector{<: Any}
 
@@ -375,7 +375,7 @@ function node(items::Tuple, vals::Trials.ValsDict)::Tuple
     )...)
 end
 function node(
-    items::Tuple, vals::Trials.ValsDict, params::Dict{Symbol, Delayed.AbstractDelayed},
+    items::Tuple, vals::Trials.ValsDict, params::Dict{Symbol, Types.AbstractDelayed},
     trials::Vector{Trials.Trial}, config::Config
 )::Tuple
 
@@ -390,7 +390,7 @@ function node(item::T, vals::Trials.ValsDict)::T where T <: Union{Real, Symbol, 
     return item
 end
 function node(
-    item::T, vals::Trials.ValsDict, params::Dict{Symbol, Delayed.AbstractDelayed},
+    item::T, vals::Trials.ValsDict, params::Dict{Symbol, Types.AbstractDelayed},
     trials::Vector{Trials.Trial}, config::Config
 )::T where T <: Union{Real, Symbol, String}
 

--- a/src/TreeParzen.jl
+++ b/src/TreeParzen.jl
@@ -3,6 +3,7 @@ module TreeParzen
 # NOTE: The files must be included in the right order - if the functions in a
 #       file depend on another file, the dependency must be loaded FIRST.
 
+include("Types.jl")
 include("SpacePrint.jl")
 include("Configuration.jl")
 include("IndexObjects.jl")

--- a/src/Trials.jl
+++ b/src/Trials.jl
@@ -20,7 +20,7 @@ $(TYPEDFIELDS)
 - `loss` : the float returned by evaluating the user's function
 """
 mutable struct Trial
-    hyperparams::Dict{Symbol, T} where T
+    hyperparams::Any
     vals::ValsDict
     loss::Float64
 end

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -1,0 +1,7 @@
+module Types
+
+abstract type AbstractDelayed end
+
+const SPACE_TYPE = Union{Dict{Symbol, T} where T, AbstractDelayed, AbstractVector{<: AbstractDelayed}}
+
+end # module

--- a/test/resolvenodes.jl
+++ b/test/resolvenodes.jl
@@ -2,11 +2,11 @@ module TestResolve
 
 using Test
 using TreeParzen
-import TreeParzen: Delayed, Resolve, Trials
+import TreeParzen: Types, Resolve, Trials
 
 @testset "Resolve.node(::Param)" begin
 
-    param = Dict{Symbol, Delayed.AbstractDelayed}(:b => HP.Normal(:a, 1.0, 2.0))
+    param = Dict{Symbol, Types.AbstractDelayed}(:b => HP.Normal(:a, 1.0, 2.0))
 
     # example to catch the key is present
     vals = Trials.ValsDict(:a => 1)

--- a/test/spaces.jl
+++ b/test/spaces.jl
@@ -64,7 +64,7 @@ trials = [ask(direct_dict_space) for i in 1:config.random_trials]
 [tell!(t, 1.) for t in trials]
 # actually, we just wanna see that this stuff doesn't vom
 newtrial = ask(direct_dict_space, trials, config)
-# Well and check that the hyperparams is a float ....
+# Well and check that the hyperparams is a dict ....
 @test newtrial.hyperparams isa Dict
 @test haskey(newtrial.hyperparams, :a)
 @test haskey(newtrial.hyperparams, :b)
@@ -83,12 +83,14 @@ trials = [ask(direct_array_space) for i in 1:config.random_trials]
 [tell!(t, 1.) for t in trials]
 # actually, we just wanna see that this stuff doesn't vom
 newtrial = ask(direct_array_space, trials, config)
-# Well and check that the hyperparams is a float ....
+# Well and check that the hyperparams is an array ....
 @test newtrial.hyperparams isa Vector
 @test length(newtrial.hyperparams) == 3
 @test 0 <= newtrial.hyperparams[1] <= 1
 @test 1 <= newtrial.hyperparams[2] <= 2
 @test 2 <= newtrial.hyperparams[3] <= 3
+
+
 
 end
 

--- a/test/spaces.jl
+++ b/test/spaces.jl
@@ -1,4 +1,4 @@
-module TesSpaces
+module TestSpaces
 
 using Test
 using TreeParzen
@@ -28,6 +28,26 @@ tp_sample = tp_trial.hyperparams
 # same holds true but we have to make sure we can sample from strings literals via TP asks
 @test tp_sample[:a] in (:a, :b, :c)
 @test tp_sample[:b] in ("a", "b", "c")
+
+
+
+# This is to test support for using inputs other than Dicts as space definitions
+direct_delayed_space = HP.Choice(:mychoice,
+    [
+        HP.Uniform(:a, 0., 1.),
+        HP.Uniform(:a, 1., 2.),
+        HP.Uniform(:a, 2., 3.),
+    ]
+)
+
+
+config = Config()
+trials = [ask(direct_delayed_space) for i in 1:config.random_trials]
+# fill them in
+[tell!(t, 1.) for t in trials]
+# actually, we just wanna see that this stuff doesn't vom
+newtrial = ask(direct_delayed_space, trials, config)
+
 
 
 end

--- a/test/spaces.jl
+++ b/test/spaces.jl
@@ -71,6 +71,25 @@ newtrial = ask(direct_dict_space, trials, config)
 
 
 
+direct_array_space = [
+    HP.Uniform(:a1, 0., 1.),
+    HP.Uniform(:a2, 1., 2.),
+    HP.Uniform(:a3, 2., 3.),
+]
+
+
+trials = [ask(direct_array_space) for i in 1:config.random_trials]
+# fill them in
+[tell!(t, 1.) for t in trials]
+# actually, we just wanna see that this stuff doesn't vom
+newtrial = ask(direct_array_space, trials, config)
+# Well and check that the hyperparams is a float ....
+@test newtrial.hyperparams isa Vector
+@test length(newtrial.hyperparams) == 3
+@test 0 <= newtrial.hyperparams[1] <= 1
+@test 1 <= newtrial.hyperparams[2] <= 2
+@test 2 <= newtrial.hyperparams[3] <= 3
+
 end
 
 true

--- a/test/spaces.jl
+++ b/test/spaces.jl
@@ -34,9 +34,9 @@ tp_sample = tp_trial.hyperparams
 # This is to test support for using inputs other than Dicts as space definitions
 direct_delayed_space = HP.Choice(:mychoice,
     [
-        HP.Uniform(:a, 0., 1.),
-        HP.Uniform(:a, 1., 2.),
-        HP.Uniform(:a, 2., 3.),
+        HP.Uniform(:a1, 0., 1.),
+        HP.Uniform(:a2, 1., 2.),
+        HP.Uniform(:a3, 2., 3.),
     ]
 )
 
@@ -47,8 +47,30 @@ trials = [ask(direct_delayed_space) for i in 1:config.random_trials]
 [tell!(t, 1.) for t in trials]
 # actually, we just wanna see that this stuff doesn't vom
 newtrial = ask(direct_delayed_space, trials, config)
+# Well and check that the hyperparams is a float ....
+@test newtrial.hyperparams isa Float64
+
+
+direct_dict_space = HP.Choice(:mychoice,
+    [
+        Dict(:a => HP.Uniform(:a1, 0., 1.), :b => HP.Uniform(:b1, 0., 1.),),
+        Dict(:a => HP.Uniform(:a2, 0., 1.), :b => HP.Uniform(:b2, 0., 1.),),
+        Dict(:a => HP.Uniform(:a3, 0., 1.), :b => HP.Uniform(:b3, 0., 1.),),
+    ]
+)
+
+trials = [ask(direct_dict_space) for i in 1:config.random_trials]
+# fill them in
+[tell!(t, 1.) for t in trials]
+# actually, we just wanna see that this stuff doesn't vom
+newtrial = ask(direct_dict_space, trials, config)
+# Well and check that the hyperparams is a float ....
+@test newtrial.hyperparams isa Dict
+@test haskey(newtrial.hyperparams, :a)
+@test haskey(newtrial.hyperparams, :b)
 
 
 
 end
+
 true


### PR DESCRIPTION
Thank you for your contribution. You're a :star: already!

Before submitting this PR, please have a look at the below checklist so that we know more about your PR.
Please also reference any relevant issues from the issues page if this PR is intended to address one of those.

## What does this PR do?

- Enables support for search spaces which are not defined as Dicts.
- `fmin` is still constrained by this requirement, however the `ask` and `tell` API has been freed up.
- Adds a `Types` module unencombered by any other modules which allows us to define top level globally applicable types without running into import loops
- Suggestions are currently broken (FIXED)
- MLJ spaces haven't yet been loosened up, not sure if it is entirely necessary given all of the MLJ models are kwarg constuctor based


## Checklist

- [x] Your code builds clean without any errors or warnings
- [x] Unit tests have been added for core changes
- [x] `julia --project -e 'using Pkg; Pkg.test()'` has been run locally and passes
- [x] Documentation has been updated with corresponding changes (if applicable)
