### PR TITLE
Cleanup some dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,7 @@ jobs:
           - '1.3'
           - '1.4'
           - '1.5'
+          - '1.6'
         os:
           # - macos-latest
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,6 @@ Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 MLJTuning = "03970b2e-30c4-11ea-3135-d1576263f10f"
-Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
@@ -19,7 +18,6 @@ Coverage = "^1.0"
 Distributions = "0.24"
 DocStringExtensions = "0.8"
 MLJTuning = "^0.6"
-Revise = "^2.5"
 SpecialFunctions = "0.8"
 julia = "1"
 

--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 [compat]
 Compat = "^1.3, ^2, ^3"
 Coverage = "^1.0"
-Distributions = "0.24"
+Distributions = "0.22, 0.24"
 DocStringExtensions = "0.8"
 MLJTuning = "^0.6"
 SpecialFunctions = "0.8"

--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 [compat]
 Compat = "^1.3, ^2, ^3"
 Coverage = "^1.0"
-Distributions = "0.22"
+Distributions = "0.24"
 DocStringExtensions = "0.8"
 MLJTuning = "^0.6"
 Revise = "^2.5"

--- a/Project.toml
+++ b/Project.toml
@@ -27,10 +27,9 @@ julia = "1"
 DecisionTree = "7806a523-6efd-50cb-b5f6-3fa6f1930dbb"
 MLJBase = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
 MLJDecisionTreeInterface = "c6f25543-311c-4c74-83dc-3ea6d1015661"
-MLJModels = "d491faf4-2d78-11e9-2867-c94bc002c0b7"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["DecisionTree", "MLJDecisionTreeInterface", "MLJBase", "MLJModels", "Statistics", "StatsBase", "Test"]
+test = ["DecisionTree", "MLJDecisionTreeInterface", "MLJBase", "Statistics", "StatsBase", "Test"]

--- a/test/MLJ/integration.jl
+++ b/test/MLJ/integration.jl
@@ -1,9 +1,9 @@
 module TestMLJIntegration
 
-using MLJBase, MLJModels, MLJTuning, TreeParzen
+using MLJBase, MLJDecisionTreeInterface, MLJTuning, TreeParzen
 X, y = @load_iris
 
-@load DecisionTreeClassifier
+import MLJDecisionTreeInterface.DecisionTreeClassifier
 
 space = (Dict(
     :min_purity_increase => HP.Uniform(:min_purity_increase, 0.0, 1.0),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,108 +1,108 @@
 using Test
 
 @time @testset "Unit Tests" begin
-    @testset "Small functions" begin
+    # @testset "Small functions" begin
 
-        @info "Bincount"
-        @test include("bincount.jl")
+    #     @info "Bincount"
+    #     @test include("bincount.jl")
 
-        @info "Configuration"
-        @test include("configuration.jl")
+    #     @info "Configuration"
+    #     @test include("configuration.jl")
 
-        @info "dfs"
-        @test include("dfs.jl")
+    #     @info "dfs"
+    #     @test include("dfs.jl")
 
-        @info "graph"
-        @test include("graph.jl")
+    #     @info "graph"
+    #     @test include("graph.jl")
 
-        @info "forgettingweights"
-        @test include("forgettingweights.jl")
+    #     @info "forgettingweights"
+    #     @test include("forgettingweights.jl")
 
-        # Needs translation from Python
-        # include("adaptive_parzen_normal_orig.jl")
+    #     # Needs translation from Python
+    #     # include("adaptive_parzen_normal_orig.jl")
 
-        @info "Trials"
-        @test include("trials.jl")
+    #     @info "Trials"
+    #     @test include("trials.jl")
 
-        @info "GMM1"
-        @test include("gmm.jl")
+    #     @info "GMM1"
+    #     @test include("gmm.jl")
 
-        @info "GMM1 Math and QGMM1 Math"
-        @test include("gmm_math.jl")
+    #     @info "GMM1 Math and QGMM1 Math"
+    #     @test include("gmm_math.jl")
 
-        @info "LGMM1"
-        @test include("lgmm.jl")
+    #     @info "LGMM1"
+    #     @test include("lgmm.jl")
 
-        @info "Resolve"
-        include("resolvenodes.jl")
+    #     @info "Resolve"
+    #     include("resolvenodes.jl")
 
-        @info "Spaces"
-        include("spaces.jl")
-    end
+    #     @info "Spaces"
+    #     include("spaces.jl")
+    # end
 
-    @testset "Larger tests" begin
-        @info "Basic"
-        @test include("basic.jl")
+    # @testset "Larger tests" begin
+    #     @info "Basic"
+    #     @test include("basic.jl")
 
-        @info "bjkomer/Squared"
-        @test include("bjkomer/squared.jl")
+    #     @info "bjkomer/Squared"
+    #     @test include("bjkomer/squared.jl")
 
-        @info "bjkomer/Function fitting"
-        @test include("bjkomer/function_fitting.jl")
+    #     @info "bjkomer/Function fitting"
+    #     @test include("bjkomer/function_fitting.jl")
 
-        @info "Official Cases"
-        @test include("official_cases.jl")
+    #     @info "Official Cases"
+    #     @test include("official_cases.jl")
 
-        @info "fmin/Quadratic"
-        @test include("fmin/quadratic.jl")
+    #     @info "fmin/Quadratic"
+    #     @test include("fmin/quadratic.jl")
 
-        @info "fmin/Return Inf"
-        @test include("fmin/return_inf.jl")
+    #     @info "fmin/Return Inf"
+    #     @test include("fmin/return_inf.jl")
 
-        @info "fmin/Submit points to Trial"
-        @test include("fmin/points.jl")
+    #     @info "fmin/Submit points to Trial"
+    #     @test include("fmin/points.jl")
 
-        @info "Silvrback"
-        @test include("silvrback.jl")
+    #     @info "Silvrback"
+    #     @test include("silvrback.jl")
 
-        @info "Vooban/Basic"
-        @test include("vooban/basic.jl")
+    #     @info "Vooban/Basic"
+    #     @test include("vooban/basic.jl")
 
-        @info "Vooban/Find min"
-        @test include("vooban/find_min.jl")
+    #     @info "Vooban/Find min"
+    #     @test include("vooban/find_min.jl")
 
-        @info "Vooban/Status Fail skip"
-        @test include("vooban/status_fail_skip.jl")
-    end
+    #     @info "Vooban/Status Fail skip"
+    #     @test include("vooban/status_fail_skip.jl")
+    # end
 
-    @testset "Samplers" begin
-        @info "hp_pchoice"
-        @test include("hp.jl")
+    # @testset "Samplers" begin
+    #     @info "hp_pchoice"
+    #     @test include("hp.jl")
 
-        @info "LogQuantNormal"
-        @test include("logquantnormal.jl")
+    #     @info "LogQuantNormal"
+    #     @test include("logquantnormal.jl")
 
-        @info "QuanLogNormal"
-        @test include("quantlognormal.jl")
+    #     @info "QuanLogNormal"
+    #     @test include("quantlognormal.jl")
 
-        @info "LogUniform"
-        @test include("loguniform.jl")
+    #     @info "LogUniform"
+    #     @test include("loguniform.jl")
 
-        @info "QuantUniform"
-        @test include("quantuniform.jl")
+    #     @info "QuantUniform"
+    #     @test include("quantuniform.jl")
 
-        @info "QuantNormal"
-        @test include("quantnormal.jl")
+    #     @info "QuantNormal"
+    #     @test include("quantnormal.jl")
 
-        @info "LogQuantUniform"
-        @test include("logquantuniform.jl")
+    #     @info "LogQuantUniform"
+    #     @test include("logquantuniform.jl")
 
-        @info "QuantLogUniform"
-        @test include("quantloguniform.jl")
+    #     @info "QuantLogUniform"
+    #     @test include("quantloguniform.jl")
 
-        @info "Uniform"
-        include("uniform.jl")
-    end
+    #     @info "Uniform"
+    #     include("uniform.jl")
+    # end
 
     @testset "MLJ" begin
         @info "MLJ Unit tests"
@@ -112,10 +112,10 @@ using Test
         @test include("MLJ/integration.jl")
     end
 
-    @info "API"
-    @test include("api.jl")
+    # @info "API"
+    # @test include("api.jl")
 
-    # Run this test last so that the print output is just above the test report
-    @info "SpacePrint"
-    @test include("spaceprint.jl")
+    # # Run this test last so that the print output is just above the test report
+    # @info "SpacePrint"
+    # @test include("spaceprint.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -112,10 +112,10 @@ using Test
         @test include("MLJ/integration.jl")
     end
 
-    # @info "API"
-    # @test include("api.jl")
+    @info "API"
+    @test include("api.jl")
 
-    # # Run this test last so that the print output is just above the test report
-    # @info "SpacePrint"
-    # @test include("spaceprint.jl")
+    # Run this test last so that the print output is just above the test report
+    @info "SpacePrint"
+    @test include("spaceprint.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,108 +1,108 @@
 using Test
 
 @time @testset "Unit Tests" begin
-    # @testset "Small functions" begin
+    @testset "Small functions" begin
 
-    #     @info "Bincount"
-    #     @test include("bincount.jl")
+        @info "Bincount"
+        @test include("bincount.jl")
 
-    #     @info "Configuration"
-    #     @test include("configuration.jl")
+        @info "Configuration"
+        @test include("configuration.jl")
 
-    #     @info "dfs"
-    #     @test include("dfs.jl")
+        @info "dfs"
+        @test include("dfs.jl")
 
-    #     @info "graph"
-    #     @test include("graph.jl")
+        @info "graph"
+        @test include("graph.jl")
 
-    #     @info "forgettingweights"
-    #     @test include("forgettingweights.jl")
+        @info "forgettingweights"
+        @test include("forgettingweights.jl")
 
-    #     # Needs translation from Python
-    #     # include("adaptive_parzen_normal_orig.jl")
+        # Needs translation from Python
+        # include("adaptive_parzen_normal_orig.jl")
 
-    #     @info "Trials"
-    #     @test include("trials.jl")
+        @info "Trials"
+        @test include("trials.jl")
 
-    #     @info "GMM1"
-    #     @test include("gmm.jl")
+        @info "GMM1"
+        @test include("gmm.jl")
 
-    #     @info "GMM1 Math and QGMM1 Math"
-    #     @test include("gmm_math.jl")
+        @info "GMM1 Math and QGMM1 Math"
+        @test include("gmm_math.jl")
 
-    #     @info "LGMM1"
-    #     @test include("lgmm.jl")
+        @info "LGMM1"
+        @test include("lgmm.jl")
 
-    #     @info "Resolve"
-    #     include("resolvenodes.jl")
+        @info "Resolve"
+        include("resolvenodes.jl")
 
-    #     @info "Spaces"
-    #     include("spaces.jl")
-    # end
+        @info "Spaces"
+        include("spaces.jl")
+    end
 
-    # @testset "Larger tests" begin
-    #     @info "Basic"
-    #     @test include("basic.jl")
+    @testset "Larger tests" begin
+        @info "Basic"
+        @test include("basic.jl")
 
-    #     @info "bjkomer/Squared"
-    #     @test include("bjkomer/squared.jl")
+        @info "bjkomer/Squared"
+        @test include("bjkomer/squared.jl")
 
-    #     @info "bjkomer/Function fitting"
-    #     @test include("bjkomer/function_fitting.jl")
+        @info "bjkomer/Function fitting"
+        @test include("bjkomer/function_fitting.jl")
 
-    #     @info "Official Cases"
-    #     @test include("official_cases.jl")
+        @info "Official Cases"
+        @test include("official_cases.jl")
 
-    #     @info "fmin/Quadratic"
-    #     @test include("fmin/quadratic.jl")
+        @info "fmin/Quadratic"
+        @test include("fmin/quadratic.jl")
 
-    #     @info "fmin/Return Inf"
-    #     @test include("fmin/return_inf.jl")
+        @info "fmin/Return Inf"
+        @test include("fmin/return_inf.jl")
 
-    #     @info "fmin/Submit points to Trial"
-    #     @test include("fmin/points.jl")
+        @info "fmin/Submit points to Trial"
+        @test include("fmin/points.jl")
 
-    #     @info "Silvrback"
-    #     @test include("silvrback.jl")
+        @info "Silvrback"
+        @test include("silvrback.jl")
 
-    #     @info "Vooban/Basic"
-    #     @test include("vooban/basic.jl")
+        @info "Vooban/Basic"
+        @test include("vooban/basic.jl")
 
-    #     @info "Vooban/Find min"
-    #     @test include("vooban/find_min.jl")
+        @info "Vooban/Find min"
+        @test include("vooban/find_min.jl")
 
-    #     @info "Vooban/Status Fail skip"
-    #     @test include("vooban/status_fail_skip.jl")
-    # end
+        @info "Vooban/Status Fail skip"
+        @test include("vooban/status_fail_skip.jl")
+    end
 
-    # @testset "Samplers" begin
-    #     @info "hp_pchoice"
-    #     @test include("hp.jl")
+    @testset "Samplers" begin
+        @info "hp_pchoice"
+        @test include("hp.jl")
 
-    #     @info "LogQuantNormal"
-    #     @test include("logquantnormal.jl")
+        @info "LogQuantNormal"
+        @test include("logquantnormal.jl")
 
-    #     @info "QuanLogNormal"
-    #     @test include("quantlognormal.jl")
+        @info "QuanLogNormal"
+        @test include("quantlognormal.jl")
 
-    #     @info "LogUniform"
-    #     @test include("loguniform.jl")
+        @info "LogUniform"
+        @test include("loguniform.jl")
 
-    #     @info "QuantUniform"
-    #     @test include("quantuniform.jl")
+        @info "QuantUniform"
+        @test include("quantuniform.jl")
 
-    #     @info "QuantNormal"
-    #     @test include("quantnormal.jl")
+        @info "QuantNormal"
+        @test include("quantnormal.jl")
 
-    #     @info "LogQuantUniform"
-    #     @test include("logquantuniform.jl")
+        @info "LogQuantUniform"
+        @test include("logquantuniform.jl")
 
-    #     @info "QuantLogUniform"
-    #     @test include("quantloguniform.jl")
+        @info "QuantLogUniform"
+        @test include("quantloguniform.jl")
 
-    #     @info "Uniform"
-    #     include("uniform.jl")
-    # end
+        @info "Uniform"
+        include("uniform.jl")
+    end
 
     @testset "MLJ" begin
         @info "MLJ Unit tests"


### PR DESCRIPTION
A continuation of #61 which adds julia 1.6 testing to CI. Additions:

- Removes MLJModels as a test dependency, to resolve 1.1 fail at #61. In tests the test model DecisionTreeClassifier is loaded directly from MLJDecisionTreeInterface instead (already a test dependency)

- Extends Distributions dep to "0.22, 0.24"

- Removes Revise dep (this is really intended for dev only). I suggest also removing Coverage, but that is not done here

I suggest adding CompatHelper to flag compatibility updates; will open separate PR for this. 

Note: SpecialFunctions is at 0.8. but latest is 1.3 - a fair gap. However, 0.9 requires julia 1.3 while TreeParzen is currently good for all julia ^1. So I wouldn't recommend any further action until a new LTS release of julia is announced (a decision re 1.6 has not been made, as far as I understand).

