### PR TITLE
Extend compat for Distributions to include 0.25

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 [compat]
 Compat = "^1.3, ^2, ^3"
 Coverage = "^1.0"
-Distributions = "0.22, 0.24"
+Distributions = "0.22, 0.24, 0.25"
 DocStringExtensions = "0.8"
 MLJTuning = "^0.6"
 SpecialFunctions = "0.8"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TreeParzen"
 uuid = "eb66a70c-a255-11e9-03ea-7ba6b2f22006"
 authors = ["iqml <https://github.com/iqml>"]
-version = "0.2.6"
+version = "0.2.7"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"


### PR DESCRIPTION
## What does this PR do?

- [ ] Provides an updated for the compatibility requirement of Distributions. Without this update users of TreeParzen cannot simultaneously use packages that require the more recent version of Distributions (released some time ago). 


## Checklist

- [x] Your code builds clean without any errors or warnings
- [x] ~~Unit tests have been added for core changes~~ - **not applicable**
- [x] `julia --project -e 'using Pkg; Pkg.test()'` has been run locally and passes
- [x] ~~Documentation has been updated with corresponding changes (if applicable)~~ **not applicable**

@kd-iqvia 