### PR TITLE
Fix invalid tests

### DIFF
--- a/test/MLJ/integration.jl
+++ b/test/MLJ/integration.jl
@@ -8,7 +8,6 @@ import MLJDecisionTreeInterface.DecisionTreeClassifier
 space = (Dict(
     :min_purity_increase => HP.Uniform(:min_purity_increase, 0.0, 1.0),
     :merge_purity_threshold => HP.Uniform(:merge_purity_threshold, 0.0, 1.0),
-    :pdf_smoothing => HP.Uniform(:pdf_smoothing, 0.0, 1.0),
 ))
 
 dtc = DecisionTreeClassifier()
@@ -31,7 +30,6 @@ fit!(mach)
 suggestion = Dict(
     :min_purity_increase => 0.6,
     :merge_purity_threshold => 0.6,
-    :pdf_smoothing => 0.6,
 )
 
 mljspace = MLJTreeParzenSpace(space, suggestion)
@@ -55,17 +53,14 @@ suggestions = [
     Dict(
         :min_purity_increase => 0.25,
         :merge_purity_threshold => 0.50,
-        :pdf_smoothing => 0.75,
     ),
     Dict(
         :min_purity_increase => 0.75,
         :merge_purity_threshold => 0.25,
-        :pdf_smoothing => 0.50,
     ),
     Dict(
         :min_purity_increase => 0.50,
         :merge_purity_threshold => 0.75,
-        :pdf_smoothing => 0.25,
     ),
 ]
 

--- a/test/gmm.jl
+++ b/test/gmm.jl
@@ -74,11 +74,11 @@ mixture_variance(weights, sigmas, means) = sum(weights .* (sigmas .^ 2)) + sum(w
     @test_throws DimensionMismatch GMM.GMM1([1.0, 0.0], [0.0, 1.0, 2.0], [10.0], 1000)
 
     # non-1 sum of weights throws
-    @test_throws ArgumentError GMM.GMM1([1., 2.], [1., 2.], [1., 2.], 1)
-    @test_throws ArgumentError GMM.GMM1([0.5, 0.6], [1., 2.], [1., 2.], 1)
-    @test_throws ArgumentError GMM.GMM1([0.2, 0.1], [1., 2.], [1., 2.], 1)
-    @test_throws ArgumentError GMM.GMM1([-1., 2.], [1., 2.], [1., 2.], 1)
-    @test_throws ArgumentError GMM.GMM1([-0.5, -0.5], [1., 2.], [1., 2.], 1)
+    @test_throws DomainError GMM.GMM1([1., 2.], [1., 2.], [1., 2.], 1)
+    @test_throws DomainError GMM.GMM1([0.5, 0.6], [1., 2.], [1., 2.], 1)
+    @test_throws DomainError GMM.GMM1([0.2, 0.1], [1., 2.], [1., 2.], 1)
+    @test_throws DomainError GMM.GMM1([-1., 2.], [1., 2.], [1., 2.], 1)
+    @test_throws DomainError GMM.GMM1([-0.5, -0.5], [1., 2.], [1., 2.], 1)
 
 end
 


### PR DESCRIPTION
CI for master is currently failing. This PR makes changes to test code to fix this. It makes no changes to source code. 

There are two tests that have become invalid, causing the fails:

1.  A **test** dependency, MLJDecisionTreeInterface, made a breaking change (the hyperparameter `pdf_smoothing` was removed from `DecisionTreeClassifier`). Since, currently, test dependency versions are unrestricted in TreeParzen.jl, this change appeared unexpectedly.  Moving forward, I suggest test dependencies be specified using [dep] entries in a separate test/Project.toml file (instead of the root Project.toml file). See this [example](https://github.com/JuliaML/TableTransforms.jl/blob/master/test/Project.toml). However, this will require julia compat to be bumped to at least Julia 1.2. I think Julia 1.6 and above is fine now for testing - Julia 1.6 is the current Long Term Release and many packages no longer support earlier versions. 

3. Distributions.jl made a change in version 0.25.44 in the way that it throws errors for probability vectors that do not sum to one. Previously an `ArgumentError` was thrown. But now a `DomainError` is thrown instead. This was technically breaking but not tagged as such. 
