### PR TITLE
replaced first with only

### DIFF
--- a/src/Delayed/normal.jl
+++ b/src/Delayed/normal.jl
@@ -9,5 +9,5 @@ struct Normal <: AbstractDistDelayed
 end
 
 function normal(mu::Float64, sigma::Float64)::Float64
-    return first(rand(Distributions.Normal(mu, sigma), 1))
+    return only(rand(Distributions.Normal(mu, sigma), 1))
 end

--- a/src/Delayed/uniform.jl
+++ b/src/Delayed/uniform.jl
@@ -9,5 +9,5 @@ struct Uniform <: AbstractDistDelayed
 end
 
 function uniform(low::Float64, high::Float64)::Float64
-    return first(rand(Distributions.Uniform(low, high), 1))
+    return only(rand(Distributions.Uniform(low, high), 1))
 end

--- a/src/Resolve/nodes.jl
+++ b/src/Resolve/nodes.jl
@@ -99,7 +99,7 @@ end
 
 
 function node(item::Delayed.CategoricalIndex, vals::Trials.ValsDict)::IndexObjects.IndexInt
-    return IndexObjects.IndexInt(first(Delayed.categoricalindex(item.probabilities, 1).v))
+    return IndexObjects.IndexInt(only(Delayed.categoricalindex(item.probabilities, 1).v))
 end
 function node(
     item::Delayed.CategoricalIndex, vals::Trials.ValsDict,

--- a/src/Samplers/adaptive_parzen.jl
+++ b/src/Samplers/adaptive_parzen.jl
@@ -21,12 +21,12 @@ function adaptive_parzen_normal(
         srtd_mus = [prior_mu]
         sigma = [prior_sigma]
     elseif length(mus) == 1
-        if prior_mu < first(mus)
-            srtd_mus = [prior_mu, first(mus)]
+        if prior_mu < only(mus)
+            srtd_mus = [prior_mu, only(mus)]
             sigma = [prior_sigma, prior_sigma * 0.5]
         else
             prior_pos = 2
-            srtd_mus = [first(mus), prior_mu]
+            srtd_mus = [only(mus), prior_mu]
             sigma = [prior_sigma * 0.5, prior_sigma]
         end
     elseif length(mus) >= 2


### PR DESCRIPTION
Thank you for your contribution. You're a :star: already!

Before submitting this PR, please have a look at the below checklist so that we know more about your PR.
Please also reference any relevant issues from the issues page if this PR is intended to address one of those.

## What does this PR do?

- closes #27 

Updated occurrences of `first` with `only` where it made sense for expected single element entries/collections to have a stricter validation. The comment on the issue on julia v1.4 and Compat is no longer relevant as the currently supported versions are from >=v1.6.
I did leave `first` in here: https://github.com/IQVIA-ML/TreeParzen.jl/blob/master/src/MLJTreeParzen.jl#L213-L214 due to a little bit more nuanced case. TreeParzen is single-objective hence using that first `entry.measure` and `entry.measurement` elements but the MLJInterface support single and multi-objective optimisation where measures can be vectors. So using `first()` in this case works whether the user provides a single measure or a vector of measures, whereas `only()` would error in the latter case. The way it is not it supports the convention of primary objective being optimised hence I left as is.

## Checklist

- [x] Your code builds clean without any errors or warnings
- [x] Unit tests have been added for core changes
- [x] `julia --project -e 'using Pkg; Pkg.test()'` has been run locally and passes
- [x] Documentation has been updated with corresponding changes (if applicable)
