### PR TITLE
removed redundant @compat use cases and dependency restrictions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ authors = ["iqml <https://github.com/iqml>"]
 version = "0.3.4"
 
 [deps]
-Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 Coverage = "a2441757-f6aa-5fb2-8edb-039e3f45d037"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
@@ -13,7 +12,6 @@ MLJTuning = "03970b2e-30c4-11ea-3135-d1576263f10f"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
-Compat = "^1.3, ^2, ^3, 4"
 Coverage = "^1.0"
 Distributions = "0.22, 0.24, 0.25"
 DocStringExtensions = "0.8, 0.9"

--- a/docs/scripts/hyperparam_images.jl
+++ b/docs/scripts/hyperparam_images.jl
@@ -1,9 +1,5 @@
 # import Pkg
 # Pkg.add("Gadfly")
-#
-# ^ you have to fight with system at the moment because of Compact conflict.
-# I edited Manifest to remove specific reference to Compat version then added
-# Gadfly, which downgrades Compat to 2.2
 
 using TreeParzen
 

--- a/src/ForgettingWeights.jl
+++ b/src/ForgettingWeights.jl
@@ -1,6 +1,5 @@
 module ForgettingWeights
 
-using Compat
 
 function forgetting_weights(N::Int, lf::Int)::Vector{Float64}
     if N < 0 throw(ArgumentError("forgetting_weights: $(N) below 0")) end
@@ -9,7 +8,7 @@ function forgetting_weights(N::Int, lf::Int)::Vector{Float64}
         return ones(N)
     end
 
-    ramp = @compat range(0., stop = 1., length = N - lf + 2)[2:end-1]
+    ramp = range(0., stop = 1., length = N - lf + 2)[2:end-1]
 
     output = vcat(ramp, ones(lf))
 

--- a/src/MLJTreeParzen.jl
+++ b/src/MLJTreeParzen.jl
@@ -53,7 +53,6 @@ module MLJTreeParzen
 
 export MLJTreeParzenTuning, MLJTreeParzenSpace
 
-using Compat
 using DocStringExtensions
 
 import MLJTuning
@@ -218,7 +217,7 @@ get_trialhist(history) =
         completed_trial
     end
 
-update_param!(model, param, val) = @compat hasproperty(model, param) ? setproperty!(model, param, val) : error("Invalid hyperparameter: $param")
+update_param!(model, param, val) = hasproperty(model, param) ? setproperty!(model, param, val) : error("Invalid hyperparameter: $param")
 
 function recursive_hyperparam_update!(model, dict)
     for (hyperparam, value) in dict

--- a/test/MLJ/unit.jl
+++ b/test/MLJ/unit.jl
@@ -1,6 +1,5 @@
 module TestMLJUnit
 
-using Compat
 using StatisticalMeasures
 using Test
 using TreeParzen

--- a/test/bjkomer/function_fitting.jl
+++ b/test/bjkomer/function_fitting.jl
@@ -4,7 +4,6 @@ https://github.com/bjkomer/hyperopt-tutorial/blob/master/Function-Fitting-Exampl
 """
 module TestFunctionFitting
 
-using Compat
 import Distributions
 using Test
 
@@ -31,7 +30,7 @@ function objective_ff(params)
 
     # Generate set of data points from a sinusoid
     num_points = 20
-    x = @compat range(0, 10; length = num_points)
+    x = range(0, 10; length = num_points)
     data = 1.5sin.(x .+ 1) .+ 2
 
     # Add noise to the data

--- a/test/forgettingweights.jl
+++ b/test/forgettingweights.jl
@@ -1,6 +1,5 @@
 module TestForgettingWeights
 
-using Compat
 import Distributions
 using Test
 

--- a/test/gmm_math.jl
+++ b/test/gmm_math.jl
@@ -1,6 +1,5 @@
 module TestGMMMath
 
-using Compat
 using Statistics
 using Test
 import TreeParzen: GMM
@@ -50,7 +49,7 @@ function test_samples(samples, c)
     bincount = samples .- samples_min
     counts = [count(x -> x == i, bincount) for i in 0:maximum(bincount)]
     @test sum(counts) == c.n_samples
-    xcoords = @compat range(samples_min, samples_max; length = length(counts)) * c.q
+    xcoords = range(samples_min, samples_max; length = length(counts)) * c.q
     prob = if :low in propertynames(c)
         exp.(GMM.GMM1_lpdf(xcoords |> collect, c.weights, c.mus, c.sigmas, c.low, c.high, c.q))
     else


### PR DESCRIPTION
Thank you for your contribution. You're a :star: already!

Before submitting this PR, please have a look at the below checklist so that we know more about your PR.
Please also reference any relevant issues from the issues page if this PR is intended to address one of those.

## What does this PR do?

- [x] Describe what your pull request does:

- closes #26 

It’s safe to remove `Compat.jl` use cases and restrictions completely and the current use of `range` and `hasproperty` because they were only relevant for compatibility with julia `v1.2` and `v1.3` which are no longer supported. TreeParzen's Julia 1.6 minimal requirement already constrains the entire dependency tree and >=1.6 julia versions support these signatures as they are making current Compat.jl  use cases redundant.

## Checklist

- [x] Your code builds clean without any errors or warnings
- [x] Unit tests have been added for core changes
- [x] `julia --project -e 'using Pkg; Pkg.test()'` has been run locally and passes
- [x] Documentation has been updated with corresponding changes (if applicable)
