### PR TITLE
removing redundant pkg dir check

### DIFF
--- a/coverage.jl
+++ b/coverage.jl
@@ -5,14 +5,7 @@ using Coverage
 
 Pkg.activate(".")
 
-# If Coverage is not installed correctly, it can fail but still exit without a
-# proper error code, which causes the calling script to report success. So we
-# wrap it in a try.
-if !isdir(Pkg.dir("Coverage"))
-    throw(LoadError(string("Coverage", 4, "Coverage is not installed correctly")))
-end
-
-# defaults to src/; alternatively, supply the folder name as argument
+# Defaults to src/; alternatively, supply the folder name as argument
 coverage = process_folder()
 # Get total coverage for all Julia files
 covered_lines, total_lines = get_summary(coverage)


### PR DESCRIPTION
Thank you for your contribution. You're a :star: already!

Before submitting this PR, please have a look at the below checklist so that we know more about your PR.
Please also reference any relevant issues from the issues page if this PR is intended to address one of those.

## What does this PR do?

- [ ] Describe what your pull request does:

- Removed deprecated `Pkg.dir()`.  It was tied to the old package layout (e.g. under .julia/v0.x)

## Checklist

- [x] Your code builds clean without any errors or warnings
- [x] Unit tests have been added for core changes
- [x] `julia --project -e 'using Pkg; Pkg.test()'` has been run locally and passes
- [x] Documentation has been updated with corresponding changes (if applicable)
