### PR TITLE
removed unused LGMM1_lpdf low and high params

### DIFF
--- a/src/LogGMM.jl
+++ b/src/LogGMM.jl
@@ -197,37 +197,11 @@ end
 """
 $(TYPEDSIGNATURES)
 
-LGMM1_lpdf without low, high
-(LGMM1_lpdf with low, high was identical)
+Log-density of each row of `samples` under a mixture of lognormals (weights, mus, sigmas).
 """
 function LGMM1_lpdf(
     samples::Matrix{Float64}, weights::Vector{Float64}, mus::Vector{Float64},
     sigmas::Vector{Float64}
-)::Vector{Float64}
-    if !(length(weights) == length(mus) == length(sigmas))
-        throw(DimensionMismatch(string(
-            "length(weights): ", length(weights),
-            " doesn't equal length(mus): ", length(mus),
-            " nor length(sigmas): ", length(sigmas),
-        )))
-    end
-
-    # compute the lpdf of each sample under each component
-    lpdfs = lognormal_lpdf(samples, mus, sigmas)
-    rval = GMM.logsum_rows(lpdfs .+ transpose(log.(weights)))
-    if length(rval) != size(samples, 1)
-        throw(DimensionMismatch(string(
-            "Length of rval (", length(rval), ") does not match size of samples (",
-            size(samples), ")"
-        )))
-    end
-
-    return rval
-end
-
-function LGMM1_lpdf(
-    samples::Matrix{Float64}, weights::Vector{Float64}, mus::Vector{Float64},
-    sigmas::Vector{Float64}, low::Float64, high::Float64
 )::Vector{Float64}
     if !(length(weights) == length(mus) == length(sigmas))
         throw(DimensionMismatch(string(

--- a/src/LogGMM.jl
+++ b/src/LogGMM.jl
@@ -133,7 +133,7 @@ function LGMM1(
     return round.(samples ./ q) .* q
 end
 
-# LGMM1_lpdf
+
 
 """
 $(TYPEDSIGNATURES)
@@ -197,7 +197,11 @@ end
 """
 $(TYPEDSIGNATURES)
 
-Log-density of each row of `samples` under a mixture of lognormals (weights, mus, sigmas).
+Log-density of each row of `samples` under a mixture of lognormals (`weights`, `mus`, `sigmas`).
+
+Matches Hyperopt `tpe.LGMM1_lpdf` with `q is None`: log-space 'low' and 'high' bounds are not in this return value
+(truncation is when drawing, e.g. `LGMM1` / `Samplers.loguniform`); with bounds and quantisation use
+`LGMM1_lpdf(..., low, high, q)`.
 """
 function LGMM1_lpdf(
     samples::Matrix{Float64}, weights::Vector{Float64}, mus::Vector{Float64},

--- a/src/Resolve/posterior.jl
+++ b/src/Resolve/posterior.jl
@@ -215,12 +215,8 @@ function posterior(
         throw(ArgumentError("b_post is empty"))
     end
 
-    below_llik = LogGMM.LGMM1_lpdf(
-        b_post, b_weights, b_mus, b_sigmas, low, high
-    )
-    above_llik = LogGMM.LGMM1_lpdf(
-        b_post, a_weights, a_mus, a_sigmas, low, high
-    )
+    below_llik = LogGMM.LGMM1_lpdf(b_post, b_weights, b_mus, b_sigmas)
+    above_llik = LogGMM.LGMM1_lpdf(b_post, a_weights, a_mus, a_sigmas)
 
     return b_post[argmax(below_llik .- above_llik)]
 end


### PR DESCRIPTION
Thank you for your contribution. You're a :star: already!

Before submitting this PR, please have a look at the below checklist so that we know more about your PR.
Please also reference any relevant issues from the issues page if this PR is intended to address one of those.

## What does this PR do?

- closes #6 :
 
Instead of creating a wrapper around `LGMM1_lpdf` without `low` and `high` params, the unused duplicate function has been removed. It's a low risk breaking change given that the `LGMM1_lpdf` is not publicly available (i.e. not exported), although it can be accessed via `TreeParzen.LogGMM`. 
These parameters matter for the `Samplers.loguniform` but not the scoring of the draws which happens in posterior only uses the mixture of params and the sample matrix. It does not re-apply `low` and `high` and they had never been used.


## Checklist

- [x] Your code builds clean without any errors or warnings
- [x] Unit tests have been added for core changes
- [x] `julia --project -e 'using Pkg; Pkg.test()'` has been run locally and passes

